### PR TITLE
footer: made contact info (phone/address) optional.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,10 +14,14 @@
   <section>
     <h2>{{ .Site.Params.footer.second_title }}</h2>
     <dl class="alt">
-      <dt>Address</dt>
-      <dd>{{.Site.Params.footer.address | markdownify }}</dd>
-      <dt>Phone</dt>
-      <dd>{{.Site.Params.footer.phone | markdownify }}</dd>
+      {{ with .Site.Params.footer.address }}
+        <dt>Address</dt>
+        <dd>{{ . | markdownify }}</dd>
+      {{ end }}
+      {{ with .Site.Params.footer.phone }}
+        <dt>Phone</dt>
+        <dd>{{ . | markdownify }}</dd>
+      {{ end }}
       <dt>Email</dt>
       <dd><a href="mailto:{{.Site.Params.footer.email}}">{{.Site.Params.footer.email | markdownify }}</a></dd>
     </dl>


### PR DESCRIPTION
Thank you for open sourcing such amazing theme. I couldn't build the site because hugo complaining some arguments were missing. I got the error message like: 
```
Building sites … ERROR 2018/06/17 10:30:18 Error while rendering "home" in "": template: index.html:86:13: executing "index.html" at <partial "footer.html...>: error calling partial: template: partials/footer.html:18:42: executing "partials/footer.html" at <markdownify>: wrong number of args for markdownify: want 1 got 0
```
Site parameters for title/description in different blocks seems to be rational to be required, but I would like to hide my contact info on the site.

This PR makes contact info in the footer optional.