### PR TITLE
Fixed typo in exampleSite/config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -42,7 +42,7 @@ googleAnalytics = "" #put your google-analytics ID here
     title = "Magna veroeros"
     description = ""
     
-    # the picture is storead at static/images/
+    # the picture is stored at static/images/
     [params.section.features]
       enable = true
       [[params.section.feature]]


### PR DESCRIPTION
- 'storead' to 'stored'